### PR TITLE
docs: README with installation, quick-start, and feature reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Per-track volume, pan, mute, solo, and FX send for all 8 tracks.
 
 ### Transport Controls
 
-Available globally from Song View, Phrase Editor (Normal), and Mixer View.
+Available from Song View and Phrase Editor (Normal Mode).
 
 | Key | Action |
 |-----|--------|


### PR DESCRIPTION
Closes #25

## What was implemented

Added `README.md` at the repo root covering everything except the narrative tutorial (left as a placeholder for the human):

- **Installation**: prerequisites (Rust stable, audio device), `cargo build --release`, binary location
- **Quick start**: `--sample` flag usage, what the user sees on launch, how to quit
- **Feature reference** — one section per view:
  - Song View (arrangement grid, all keybindings)
  - Chain View (normal and insert modes)
  - Phrase Editor (normal mode, insert mode with full QWERTY piano layout table, FX entry)
  - Instrument Editor (all 8 fields, text edit mode)
  - Sample Browser
  - Mixer View (all 5 fields, all keys)
- **Transport controls** (global)
- **Command mode** (`:w`, `:e`, `:export-json`, `:export-mix`, `:export-stems`)
- **FX commands** (VOL, PAN, PIT, RET with value ranges)
- **File formats** (`.trk` bincode vs JSON, v1/v2 compatibility note)
- **Tutorial placeholder** block

All keybindings were read directly from `tracker/src/main.rs` — nothing invented.

## Limitations / known rough edges
- The Mixer View is accessible via `F2` from Song View but this is not exposed as a view navigation target from Chain/Phrase Editor; not documented as such.
- The `--sample` flag is the only CLI flag; there is no `--help` output.

— Ralph 🤖