### PR TITLE
feat: live phrase editing during arrangement playback

### DIFF
--- a/tracker-core/src/audio.rs
+++ b/tracker-core/src/audio.rs
@@ -45,6 +45,9 @@ pub enum Command {
         phrases: Vec<Phrase>,
         instruments: Vec<Instrument>,
     },
+    /// Replace a single phrase in the sequencer's arrangement phrase table.
+    /// Cheaper than `UpdateSongData` — used for live phrase edits during playback.
+    UpdatePhraseInSong { idx: usize, phrase: Box<Phrase> },
     /// Set the output volume for track `track` (0.0–2.0).  Takes effect immediately.
     SetTrackVolume { track: u8, volume: f32 },
     /// Set the stereo pan for track `track` (-1.0 to 1.0).  Takes effect immediately.
@@ -433,6 +436,14 @@ impl Sequencer {
         self.chains = chains;
         self.phrases_data = phrases;
         self.instruments = instruments;
+    }
+
+    /// Patch a single phrase in `phrases_data` for live editing during playback.
+    /// Has no effect if `idx` is out of range (e.g. arrangement not yet loaded).
+    pub fn update_phrase_in_song(&mut self, idx: usize, phrase: Box<Phrase>) {
+        if let Some(slot) = self.phrases_data.get_mut(idx) {
+            *slot = *phrase;
+        }
     }
 
     /// Resolve the playback speed for `track` at `step_idx`, using the arrangement
@@ -1127,4 +1138,67 @@ mod tests {
             assert_eq!(slot.value, 0, "empty FX slot value should be 0");
         }
     }
+
+    #[test]
+    fn update_phrase_in_song_patches_live_during_playback() {
+        use crate::model::{Chain, ChainSlot, Phrase, TRACKS};
+
+        let mut seq = Sequencer::new(48000.0, 120.0);
+
+        // Initial phrase: step 0 = note 60 (speed 1.0 at root 60).
+        let mut p = Phrase::default();
+        p.steps[0].note = Some(60);
+
+        let chains = vec![Chain {
+            slots: vec![ChainSlot { phrase: 0, transpose: 0 }],
+        }];
+        let mut row = [None; TRACKS];
+        row[0] = Some(0);
+        let arrangement = vec![row];
+
+        seq.update_song_data(arrangement, chains, vec![p], vec![]);
+        seq.sample_root = 60;
+        let initial = seq.restart();
+
+        // Confirm step 0 fires at speed 1.0.
+        let t0_speed = initial.iter().find(|&&(t, _)| t == 0).map(|&(_, s)| s);
+        assert!(t0_speed.is_some(), "track 0 should fire on step 0");
+        assert!(
+            (t0_speed.unwrap() - 1.0).abs() < 1e-4,
+            "initial speed should be 1.0 (note 60, root 60)"
+        );
+
+        // Live edit: change phrase 0 step 0 to note 72 (+1 octave → speed 2.0).
+        let mut edited = Phrase::default();
+        edited.steps[0].note = Some(72);
+        seq.update_phrase_in_song(0, Box::new(edited));
+
+        // Advance a full phrase cycle (16 steps). The last event in this batch
+        // is step 0 wrapping around — it should use the updated phrase.
+        let events = seq.advance(16 * 6000);
+        assert_eq!(events.len(), 16, "should get exactly 16 step events");
+        let wrap_event = events.last().unwrap();
+        assert_eq!(wrap_event.step_index, 0, "last event should be step 0 after wrap");
+        assert!(
+            !wrap_event.notes.is_empty(),
+            "step 0 should have a note after the live edit"
+        );
+        let (track, speed, _) = &wrap_event.notes[0];
+        assert_eq!(*track, 0);
+        assert!(
+            (speed - 2.0).abs() < 1e-4,
+            "after live edit, speed should be 2.0 (note 72, root 60), got {speed}"
+        );
+    }
+
+    #[test]
+    fn update_phrase_in_song_out_of_range_is_ignored() {
+        use crate::model::Phrase;
+        let mut seq = Sequencer::new(48000.0, 120.0);
+        // No song data loaded — phrases_data is empty.
+        let phrase = Box::new(Phrase::default());
+        // Should not panic.
+        seq.update_phrase_in_song(99, phrase);
+    }
+
 }

--- a/tracker/src/main.rs
+++ b/tracker/src/main.rs
@@ -299,7 +299,11 @@ impl App {
     /// Push a fresh phrase snapshot to the sequencer.
     fn sync_phrase_to_sequencer(&mut self) {
         let phrase = Box::new(self.phrase().clone());
-        self.send_cmd(Command::UpdatePhrase(phrase));
+        self.send_cmd(Command::UpdatePhrase(phrase.clone()));
+        self.send_cmd(Command::UpdatePhraseInSong {
+            idx: self.active_phrase_idx,
+            phrase,
+        });
         self.send_cmd(Command::SetSampleRoot(self.sample_root));
     }
 
@@ -951,6 +955,9 @@ fn start_audio_stream(
                     }
                     Command::UpdateSongData { arrangement, chains, phrases, instruments } => {
                         sequencer.update_song_data(arrangement, chains, phrases, instruments);
+                    }
+                    Command::UpdatePhraseInSong { idx, phrase } => {
+                        sequencer.update_phrase_in_song(idx, phrase);
                     }
                     Command::SetTrackVolume { track, volume } => {
                         if (track as usize) < TRACKS {


### PR DESCRIPTION
Closes #39

## What was implemented

In arrangement mode, phrase edits were only visible to the audio thread when a full `UpdateSongData` snapshot was sent (e.g. on file load or chain edits). The phrase editor called `sync_phrase_to_sequencer()` after every note/FX change, but that only updated `sequencer.phrase` — the legacy single-phrase field not used during arrangement playback. The sequencer's `phrases_data` Vec stayed stale.

### Fix

Added a new `Command::UpdatePhraseInSong { idx, phrase }` that patches a single entry in `phrases_data` in-place. `sync_phrase_to_sequencer()` now also sends this command with `active_phrase_idx`, so every edit in the Phrase Editor reaches the audio thread within one ring buffer poll cycle (~5 ms) — well before the next sequencer step fires (~125 ms at 120 BPM).

No locks are acquired. The existing lock-free `rtrb` ring buffer carries the update; the audio callback simply swaps one element.

### Files changed

- `tracker-core/src/audio.rs` — new `Command::UpdatePhraseInSong` variant; `Sequencer::update_phrase_in_song()` method; two new tests
- `tracker/src/main.rs` — handle new command in audio callback; `sync_phrase_to_sequencer()` sends both `UpdatePhrase` (legacy) and `UpdatePhraseInSong`

## Limitations / known rough edges

- Instrument changes during playback are not yet live (they are snapshotted in `UpdateSongData`); this is outside the scope of issue #39.