### PR TITLE
feat: dirty flag and quit confirmation modal

### DIFF
--- a/tracker/src/main.rs
+++ b/tracker/src/main.rs
@@ -812,6 +812,7 @@ impl App {
         let current = self.song.clone();
         if let Some((snapshot, desc)) = self.history.undo(current) {
             self.song = snapshot;
+            self.is_dirty = true;
             self.set_timed_status(format!("Undid: {desc}"));
             self.sync_phrase_to_sequencer();
             self.sync_song_to_sequencer();
@@ -826,6 +827,7 @@ impl App {
         let current = self.song.clone();
         if let Some((snapshot, desc)) = self.history.redo(current) {
             self.song = snapshot;
+            self.is_dirty = true;
             self.set_timed_status(format!("Redid: {desc}"));
             self.sync_phrase_to_sequencer();
             self.sync_song_to_sequencer();


### PR DESCRIPTION
Closes #53

## What was implemented

- **Dirty flag** — `is_dirty: bool` added to `App`. Set to `true` inside `record()` (called before every undoable mutation), cleared to `false` on a successful `:w` save or `:e` load.
- **Quit confirmation modal** — New `InputMode::ConfirmQuit` variant. Pressing `q` with unsaved changes switches to this mode instead of quitting immediately; pressing `q` with no unsaved changes quits as before.
- **Modal rendering** — Centered overlay using ratatui `Clear` + `Paragraph` with a border, rendered after the main view and before the status bar. Establishes the first modal pattern in the app.
- **Status bar hint** — While the modal is active the status bar shows `Unsaved changes — y: quit  n/Esc: cancel`.
- **Keys** — `y`/`Y` confirms quit; `n`/`N`/`Esc` dismisses the modal and returns to Normal.
- **Unit tests** — Three new tests verify `is_dirty` is false at startup, true after `record()`, and true after `enter_note()`.

## Limitations / known rough edges

- The startup screen also gates `q` behind the dirty check for consistency, but in practice `is_dirty` will always be false there since no mutations are possible before navigating into a project.