### PR TITLE
feat: audio preview infrastructure — PreviewSample and StopPreview

### DIFF
--- a/tracker-core/src/audio.rs
+++ b/tracker-core/src/audio.rs
@@ -56,6 +56,12 @@ pub enum Command {
     SetTrackMute { track: u8, mute: bool },
     /// Toggle solo on track `track`.  When any track is soloed, non-soloed tracks are silent.
     SetTrackSolo { track: u8, active: bool },
+    /// Load a sample into the dedicated preview voice and start playback from the beginning.
+    /// Does not affect any instrument slot.
+    PreviewSample { samples: Arc<Vec<f32>>, channels: usize },
+    /// Halt playback on the dedicated preview voice immediately.
+    /// Does not affect any instrument slot.
+    StopPreview,
 }
 
 /// 4-point Hermite cubic interpolation for the "Sinc" quality mode.
@@ -1199,6 +1205,59 @@ mod tests {
         let phrase = Box::new(Phrase::default());
         // Should not panic.
         seq.update_phrase_in_song(99, phrase);
+    }
+
+    #[test]
+    fn preview_sample_command_triggers_active_voice() {
+        // Simulate what the audio thread does for Command::PreviewSample.
+        let samples = Arc::new(vec![0.1f32; 4800]); // 0.1s mono at 48 kHz
+        let channels = 1usize;
+
+        // Verify the command can be constructed with expected data.
+        let cmd = Command::PreviewSample { samples: Arc::clone(&samples), channels };
+        let Command::PreviewSample { samples: cmd_samples, channels: cmd_channels } = cmd else {
+            panic!("wrong variant");
+        };
+        assert_eq!(cmd_channels, 1);
+        assert_eq!(cmd_samples.len(), 4800);
+
+        // Simulate the audio-thread handler: create a voice, trigger it.
+        let mut voice = Voice::new(cmd_samples, cmd_channels);
+        voice.trigger(1.0);
+        assert!(voice.is_active(), "preview voice should be active after trigger");
+    }
+
+    #[test]
+    fn stop_preview_command_halts_preview_voice() {
+        let samples = Arc::new(vec![0.5f32; 960]);
+        let mut voice = Voice::new(Arc::clone(&samples), 1);
+        voice.trigger(1.0);
+        assert!(voice.is_active());
+
+        // Simulate Command::StopPreview handler.
+        voice.stop();
+        assert!(!voice.is_active(), "preview voice should be inactive after stop");
+    }
+
+    #[test]
+    fn preview_voice_does_not_interfere_with_mixer_slots() {
+        let samples = Arc::new(vec![1.0f32, 1.0f32, 1.0f32, 1.0f32]); // 2 mono frames
+        let instr_samples = Arc::new(vec![0.5f32, 0.5f32, 0.5f32, 0.5f32]);
+
+        let mut mixer = Mixer::new();
+        mixer.load_slot(0, Voice::new(Arc::clone(&instr_samples), 1));
+        mixer.trigger(0, 1.0);
+
+        // Preview voice is separate — stopping it doesn't touch mixer slot 0.
+        let mut preview = Voice::new(Arc::clone(&samples), 1);
+        preview.trigger(1.0);
+        preview.stop();
+
+        // Instrument slot 0 should still be active.
+        let mut output = vec![0.0f32; 4];
+        mixer.render(&mut output);
+        // At least some non-zero samples were contributed by the instrument slot.
+        assert!(output.iter().any(|&s| s != 0.0), "instrument slot should still render after preview stop");
     }
 
 }

--- a/tracker/src/main.rs
+++ b/tracker/src/main.rs
@@ -993,6 +993,9 @@ fn start_audio_stream(
 
     let mut sequencer = Sequencer::new(48000.0, initial_bpm);
 
+    // Dedicated preview voice — separate from the 16 instrument slots.
+    let mut preview_voice: Option<Voice> = None;
+
     // Per-track mixer state: updated by SetTrackVolume/Pan/Mute/Solo commands.
     let mut track_volumes = [1.0f32; TRACKS];
     let mut track_pans = [0.0f32; TRACKS];
@@ -1090,6 +1093,14 @@ fn start_audio_stream(
                             track_solo[track as usize] = active;
                         }
                     }
+                    Command::PreviewSample { samples, channels } => {
+                        let mut v = Voice::new(samples, channels);
+                        v.trigger(1.0);
+                        preview_voice = Some(v);
+                    }
+                    Command::StopPreview => {
+                        preview_voice = None;
+                    }
                 }
             }
 
@@ -1150,6 +1161,14 @@ fn start_audio_stream(
             }
 
             mixer.render(data);
+
+            // Mix the preview voice on top of the instrument voices.
+            if let Some(pv) = preview_voice.as_mut() {
+                pv.render(data);
+                if !pv.is_active() {
+                    preview_voice = None;
+                }
+            }
         },
         |err| eprintln!("audio stream error: {err}"),
         None,


### PR DESCRIPTION
Closes #52

## What was implemented

- **`Command::PreviewSample { samples, channels }`** — new variant in `tracker-core/src/audio.rs` that loads sample data into a dedicated preview voice and starts playback from the beginning.
- **`Command::StopPreview`** — new variant that halts the preview voice immediately.
- **Dedicated preview voice** — `preview_voice: Option<Voice>` in `start_audio_stream`, completely separate from the 16 instrument slots. Instrument slot playback is unaffected by preview commands.
- **Auto-completion** — the preview voice self-deactivates and is cleared when the sample plays to completion (one-shot, no looping).
- **Mixing** — the preview voice renders into the output buffer after the main `Mixer` render, so both can play concurrently without interference.
- **3 unit tests** in `tracker-core/src/audio.rs` verifying: `PreviewSample` triggers an active voice; `StopPreview` halts it; stopping the preview does not affect instrument slots.

## Limitations

- No volume or pan control on the preview voice (plays at full volume, centre pan). Per the PRD, looping/trimming/volume control are out of scope.