### PR TITLE
feat: :bpm command for direct BPM entry

### DIFF
--- a/tracker/src/main.rs
+++ b/tracker/src/main.rs
@@ -750,11 +750,15 @@ impl App {
             } else {
                 match rest.parse::<f32>() {
                     Ok(bpm) => {
-                        let clamped = bpm.clamp(20.0, 999.0);
-                        self.record("set BPM");
-                        self.song.bpm = clamped;
-                        self.send_cmd(Command::SetBpm(clamped));
-                        self.set_timed_status(format!("BPM set to {clamped:.1}"));
+                        if !bpm.is_finite() {
+                            self.status = format!("Invalid BPM value: '{rest}' — expected a number");
+                        } else {
+                            let clamped = bpm.clamp(20.0, 999.0);
+                            self.record("set BPM");
+                            self.song.bpm = clamped;
+                            self.send_cmd(Command::SetBpm(clamped));
+                            self.set_timed_status(format!("BPM set to {clamped:.1}"));
+                        }
                     }
                     Err(_) => {
                         self.status = format!("Invalid BPM value: '{rest}' — expected a number");
@@ -3304,6 +3308,16 @@ mod tests {
         assert!((app.song.bpm - 180.0).abs() < 1e-4);
         app.do_undo();
         assert!((app.song.bpm - original_bpm).abs() < 1e-4, "undo should restore original BPM");
+    }
+
+    #[test]
+    fn execute_bpm_nan_shows_error_and_does_not_corrupt_bpm() {
+        let mut app = make_app();
+        let original_bpm = app.song.bpm;
+        app.cmd_buf = "bpm nan".to_string();
+        app.execute_command();
+        assert!(app.status.contains("Invalid BPM"), "expected error, got: {}", app.status);
+        assert_eq!(app.song.bpm, original_bpm, "NaN must not corrupt song.bpm");
     }
 
     #[test]


### PR DESCRIPTION
Closes #51

## What was implemented

Added a `bpm <value>` handler inside `execute_command()` following the existing command pattern:

- `:bpm 140` — sets BPM to 140.0, reflected immediately in the transport display
- `:bpm 10` — clamps to 20.0 (minimum), no error
- `:bpm 1000` — clamps to 999.0 (maximum), no error
- `:bpm foo` — descriptive error message in the status bar
- `:bpm` (no value) — usage hint shown in the status bar
- Calls `record()` before mutating so the change is undoable with `u`
- Sends `Command::SetBpm` to update the audio thread immediately

## Tests

6 unit tests: valid input, clamp-low, clamp-high, invalid string, missing value, undo behaviour.