### PR TITLE
chore: update docs and tooling to use vitakt name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Rename Cargo workspace and crate names from `tracker`/`tracker-core` to `vitakt`/`vitakt-core`; rename source directories accordingly (#62)
 - Rename user-visible strings, config path (`~/.config/vitakt/theme.toml`), usage messages, and internal test fixtures from `tracker` to `vitakt`; add one-time migration that copies `~/.config/tracker/theme.toml` to the new location on first run (#63)
+- Update README, CHANGELOG, and `theme.example.toml` to reflect the `vitakt` name (#64)
 
 ## [0.1.1] - 2026-03-22
 
@@ -47,7 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `:bpm <value>` command for setting BPM directly from the command line ([#51](https://github.com/ajrussellaudio/tracker/issues/51))
 - Status bar redesign: mode label shown first; Insert mode uses a distinct background colour ([#42](https://github.com/ajrussellaudio/tracker/issues/42))
 - Startup screen with project info and key bindings ([#40](https://github.com/ajrussellaudio/tracker/issues/40))
-- Theme system: load custom colours from `~/.config/tracker/theme.toml` ([#14](https://github.com/ajrussellaudio/tracker/issues/14))
+- Theme system: load custom colours from `~/.config/vitakt/theme.toml` ([#14](https://github.com/ajrussellaudio/tracker/issues/14))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tracker
+# vitakt
 
 A CLI/TUI sample-based music tracker written in Rust. Arrange samples into phrases, chain phrases into sequences, and mix 8 independent tracks — all from the terminal.
 
@@ -8,13 +8,13 @@ A CLI/TUI sample-based music tracker written in Rust. Arrange samples into phras
 
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf \
-  https://github.com/ajrussellaudio/tracker/releases/latest/download/tracker-installer.sh | sh
+  https://github.com/ajrussellaudio/vitakt/releases/latest/download/vitakt-installer.sh | sh
 ```
 
 Then launch with:
 
 ```bash
-tracker
+vitakt
 ```
 
 ### Build from source
@@ -24,19 +24,19 @@ tracker
 - A system audio device (ALSA on Linux, CoreAudio on macOS, WASAPI on Windows)
 
 ```bash
-git clone https://github.com/ajrussellaudio/tracker
-cd tracker
+git clone https://github.com/ajrussellaudio/vitakt
+cd vitakt
 cargo build --release
 ```
 
-The binary is at `target/release/tracker`. Run it with `cargo run --release` during development.
+The binary is at `target/release/vitakt`. Run it with `cargo run --release` during development.
 
 ## Quick Start
 
 Launch with no arguments to see the startup screen. If installed from the pre-built binary:
 
 ```bash
-tracker
+vitakt
 ```
 
 Or, when running from source:
@@ -50,7 +50,7 @@ On the startup screen, choose **New Project** to open a blank song, or **Open Fi
 To open a project directly (useful in scripts or shell aliases), pass the path as a positional argument:
 
 ```bash
-tracker path/to/my-song.trk
+vitakt path/to/my-song.trk
 # or from source:
 cargo run --release -- path/to/my-song.trk
 ```
@@ -277,7 +277,7 @@ Lists `.wav` files and subdirectories in the current browsing directory.
 
 ### Startup Screen
 
-Shown when `tracker` is launched with no arguments.
+Shown when `vitakt` is launched with no arguments.
 
 | Key | Action |
 |-----|--------|

--- a/theme.example.toml
+++ b/theme.example.toml
@@ -1,5 +1,5 @@
-# tracker theme configuration
-# Place this file at ~/.config/tracker/theme.toml to apply a custom color theme.
+# vitakt theme configuration
+# Place this file at ~/.config/vitakt/theme.toml to apply a custom color theme.
 #
 # All values are hex color strings in #RRGGBB format.
 # On terminals without true-color support (COLORTERM != truecolor/24bit),


### PR DESCRIPTION
Closes #64

## Summary

Updates all human-readable files and tooling config to reflect the new `vitakt` name.

### Changes
- `README.md`: heading → `vitakt`; install one-liner uses `vitakt-installer.sh` and `ajrussellaudio/vitakt`; git clone URL, `cd` directory, binary path, and invocation examples all updated
- `CHANGELOG.md`: config path entry updated from `~/.config/tracker/theme.toml` to `~/.config/vitakt/theme.toml`
- `theme.example.toml`: header comment and install path comment updated to `vitakt`
- `.github/workflows/release.yml`: re-ran `dist generate` — no changes needed (artifact names are computed dynamically from the Cargo manifest)
- `ralph/project.md` **not** changed (handled by #65)

### Verification
- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `grep -r "tracker" --include="*.md" --include="*.toml" --include="*.yml"` returns only historical CHANGELOG rename descriptions and `plans/` planning docs — no live project-name uses